### PR TITLE
🐛 fix(remote): resolve SSH sync compatibility issues with fish shell and SCP

### DIFF
--- a/services/RemoteSessionMirror.swift
+++ b/services/RemoteSessionMirror.swift
@@ -329,7 +329,8 @@ actor RemoteSessionMirror {
         let quotedBase = doubleQuoted(base)
         let pathArgs = searchPaths.map { doubleQuoted($0) }.joined(separator: " ")
         // Use /bin/sh -c to ensure POSIX shell execution regardless of remote login shell (e.g., fish)
-        let innerCommand = "cd \(quotedBase) && { find \(pathArgs) -type f -name '*.jsonl' -printf '%p|%s|%T@\\n' 2>/dev/null || true; }"
+        // Use double quotes for find arguments to avoid nested single-quote escaping complexity
+        let innerCommand = "cd \(quotedBase) && { find \(pathArgs) -type f -name \"*.jsonl\" -printf \"%p|%s|%T@\\n\" 2>/dev/null || true; }"
         return "/bin/sh -c '\(innerCommand.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
 


### PR DESCRIPTION
## Summary
- Wrap remote find command in `/bin/sh -c` to ensure POSIX shell execution regardless of remote login shell (fixes fish shell compatibility)
- Add `buildBaseSCPOptions` with SCP-specific option syntax (`-P` for port instead of `-p`)
- Add `scpConnectionTarget` to use `user@host` format (SCP doesn't support `-l` flag)
- Handle edge case where hostname already contains `@` symbol

## Test plan
- [ ] Test SSH sync with remote server using fish as default shell
- [ ] Test SCP transfer with custom port configuration
- [ ] Test SCP transfer with explicit user configuration
- [ ] Verify existing SSH sync functionality remains unaffected